### PR TITLE
fixed button in payment types

### DIFF
--- a/bangazon/src/components/home/Home.css
+++ b/bangazon/src/components/home/Home.css
@@ -3,8 +3,6 @@
     font-size: 20px;
     background-color: #3f51b5;
     box-shadow: 1px 1px;
-    margin: 20px;
-    border-radius: 10px;
     padding: 20%;
     color: white;
     background-image: url('./homenav-ConvertImage.jpg');
@@ -33,7 +31,7 @@
 
 .bangazon-top-20 {
     text-align: center;
-    margin: 10px;
+    margin-top: 30px;
     font-size: 30px;
 }
 

--- a/bangazon/src/components/myAccount/Profile.js
+++ b/bangazon/src/components/myAccount/Profile.js
@@ -31,6 +31,7 @@ class Profile extends Component {
 
     state = {
         paymenttypes: [],
+        isThere: false
     };
 
     handleFieldChange = evt => {
@@ -38,7 +39,17 @@ class Profile extends Component {
         stateToChange[evt.target.id] = evt.target.value
         this.setState(stateToChange)
     }
-
+    componentDidMount() {
+        APIManager.getAll("paymenttypes")
+            .then((response) => {
+                console.log(response.length)
+                if (response.length !== 0) {
+                    this.setState({
+                        isThere: true
+                    })
+                }
+            })
+    }
 
     getPaymentTypes = () => {
         // Gets all payment types, then sets them in state to load the cards later
@@ -55,9 +66,16 @@ class Profile extends Component {
             .then(() => {
                 APIManager.getAll("paymenttypes")
                     .then((response) => {
-                        this.setState({
-                            paymenttypes: response
-                        })
+                        if (response.length === 0) {
+                            this.setState({
+                                isThere: false,
+                                paymenttypes: response
+                            })
+                        } else {
+                            this.setState({
+                                paymenttypes: response
+                            })
+                        }
                     })
             })
     }
@@ -71,27 +89,27 @@ class Profile extends Component {
             <>
                 <div className="profile-container">
                     <div className="payment-button-container">
-                        {this.state.paymenttypes.length === 0 && 
-                        
-                        <Button id="payment-button" variant="contained" color="light" className={classes.button} disabled={this.state.loadingStatus}
-                            onClick={() => this.getPaymentTypes()}>
-                            View Payment Options
+                        {this.state.paymenttypes.length === 0 && this.state.isThere === true &&
+
+                            <Button id="payment-button" variant="contained" color="light" className={classes.button} disabled={this.state.loadingStatus}
+                                onClick={() => this.getPaymentTypes()}>
+                                View Payment Options
                         </Button>
-                            }
+                        }
 
                         <Button id="payment-button" variant="contained" color="dark" className={classes.button} disabled={this.state.loadingStatus}
                             onClick={() => this.props.history.push('/payment/new')}>
                             Add a New Payment Option
                     </Button>
-                    <Button variant="contained">
-                    <Link
-                      to={{
-                        pathname: `/orderhistory`,
-                        
-                      }} className="complete-order-button">
-                      View Order History
+                        <Button variant="contained">
+                            <Link
+                                to={{
+                                    pathname: `/orderhistory`,
+
+                                }} className="complete-order-button">
+                                View Order History
                     </Link>
-                  </Button>
+                        </Button>
                     </div>
                     <PaymentList paymenttypes={this.state.paymenttypes} deletePaymentType={this.deletePaymentType} />
 


### PR DESCRIPTION
# Description
Fixed the view payment types button appearing when the user has no payment types.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions
1. `git fetch --all`
2. `git checkout lr-payment-button-bug-fix-67`
3. Go to profile and delete all payment types. The view payment types button should be gone. Create 2 new payment types. Select view payment types. Delete both of them. The view payment types button should not appear after you delete the last one. 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
- [x] My functions have doc strings
